### PR TITLE
failover loglevel changed to warning when connection is in reader mode

### DIFF
--- a/src/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeper.php
+++ b/src/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeper.php
@@ -43,6 +43,7 @@ final class FailoverAwareAliveKeeper implements AliveKeeper
      * @param Connection      $connection
      * @param string          $connectionName
      * @param string          $connectionType
+     * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public function __construct(
         LoggerInterface $logger,
@@ -64,7 +65,8 @@ final class FailoverAwareAliveKeeper implements AliveKeeper
     {
         try {
             if (!$this->isProperConnection()) {
-                $this->logger->alert(sprintf('Failover reconnect for connection \'%s\'', $this->conntectionName));
+                $logLevel = $this->connectionType->isWriter() ? 'alert' : 'warning';
+                $this->logger->{$logLevel}(sprintf('Failover reconnect for connection \'%s\'', $this->conntectionName));
                 $this->reconnect();
             }
         } catch (DBALException $e) {

--- a/src/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeper.php
+++ b/src/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeper.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\DBALException;
 use Exception;
 use PixelFederation\DoctrineResettableEmBundle\DBAL\Connection\AliveKeeper;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  */
@@ -65,8 +66,11 @@ final class FailoverAwareAliveKeeper implements AliveKeeper
     {
         try {
             if (!$this->isProperConnection()) {
-                $logLevel = $this->connectionType->isWriter() ? 'alert' : 'warning';
-                $this->logger->{$logLevel}(sprintf('Failover reconnect for connection \'%s\'', $this->conntectionName));
+                $logLevel = $this->connectionType->isWriter() ? LogLevel::ALERT : LogLevel::WARNING;
+                $this->logger->log(
+                    $logLevel,
+                    sprintf('Failover reconnect for connection \'%s\'', $this->conntectionName)
+                );
                 $this->reconnect();
             }
         } catch (DBALException $e) {

--- a/tests/Unit/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeperTest.php
+++ b/tests/Unit/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeperTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 class FailoverAwareAliveKeeperTest extends TestCase
 {
@@ -74,7 +75,7 @@ class FailoverAwareAliveKeeperTest extends TestCase
     public function testKeepAliveWriterWithReconnectOnFailover(): void
     {
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
-        $loggerProphecy->alert(Argument::any())->shouldBeCalled();
+        $loggerProphecy->log(LogLevel::ALERT, Argument::any())->shouldBeCalled();
         $statementProphecy = $this->prophesize(Statement::class);
         $statementProphecy->fetchColumn(0)->willReturn('1')->shouldBeCalled();
 
@@ -98,7 +99,7 @@ class FailoverAwareAliveKeeperTest extends TestCase
     public function testKeepAliveReaderWithReconnectOnFailover(): void
     {
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
-        $loggerProphecy->warning(Argument::any())->shouldBeCalled();
+        $loggerProphecy->log(LogLevel::WARNING, Argument::any())->shouldBeCalled();
         $statementProphecy = $this->prophesize(Statement::class);
         $statementProphecy->fetchColumn(0)->willReturn('0')->shouldBeCalled();
 

--- a/tests/Unit/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeperTest.php
+++ b/tests/Unit/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeperTest.php
@@ -98,7 +98,7 @@ class FailoverAwareAliveKeeperTest extends TestCase
     public function testKeepAliveReaderWithReconnectOnFailover(): void
     {
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
-        $loggerProphecy->alert(Argument::any())->shouldBeCalled();
+        $loggerProphecy->warning(Argument::any())->shouldBeCalled();
         $statementProphecy = $this->prophesize(Statement::class);
         $statementProphecy->fetchColumn(0)->willReturn('0')->shouldBeCalled();
 
@@ -123,7 +123,7 @@ class FailoverAwareAliveKeeperTest extends TestCase
     public function testKeepAliveWithReconnectConnectionError(): void
     {
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
-        $loggerProphecy->critical(Argument::any())->shouldBeCalled();
+        $loggerProphecy->info(Argument::any(), Argument::any())->shouldBeCalled();
         $statementProphecy = $this->prophesize(Statement::class);
         $statementProphecy->fetchColumn(0)->willThrow(DBALException::class)->shouldBeCalled();
 


### PR DESCRIPTION
it's possible that alert log level combined with reader failover would wake up people unnecesarily