### PR TITLE
fix in failover alive keeper - second reconnection made problems and broke the game so the call was removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 vendor
 .php_cs.cache
 .phpunit.result.cache
+docker-compose.override.yml
 tests/Functional/app/data/*
 !tests/Functional/app/data/.gitkeep

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.5'
 
 services:
   # PHP

--- a/src/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeper.php
+++ b/src/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeper.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\DBALException;
 use Exception;
 use PixelFederation\DoctrineResettableEmBundle\DBAL\Connection\AliveKeeper;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  */
@@ -43,6 +44,7 @@ final class FailoverAwareAliveKeeper implements AliveKeeper
      * @param Connection      $connection
      * @param string          $connectionName
      * @param string          $connectionType
+     * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public function __construct(
         LoggerInterface $logger,
@@ -64,7 +66,11 @@ final class FailoverAwareAliveKeeper implements AliveKeeper
     {
         try {
             if (!$this->isProperConnection()) {
-                $this->logger->alert(sprintf('Failover reconnect for connection \'%s\'', $this->conntectionName));
+                $logLevel = $this->connectionType->isWriter() ? LogLevel::ALERT : LogLevel::WARNING;
+                $this->logger->log(
+                    $logLevel,
+                    sprintf('Failover reconnect for connection \'%s\'', $this->conntectionName)
+                );
                 $this->reconnect();
             }
         } catch (DBALException $e) {
@@ -74,7 +80,6 @@ final class FailoverAwareAliveKeeper implements AliveKeeper
                     'exception' => $e,
                 ]
             );
-            $this->reconnect();
         }
     }
 


### PR DESCRIPTION
When there is a problem in the FailoverAliveKeeper, the keeper should not break the app with an exception. The AliveKeeper should be transparent.