### PR TITLE
Fix for failover alive keeper regression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,10 @@
   },
   "config": {
     "sort-packages": true
+  },
+  "scripts": {
+    "phpcs": "phpcs --standard=phpcs.ruleset.xml src",
+    "php-cs-fixer": "php-cs-fixer --config=./.php_cs fix src",
+    "phpmd": "phpmd src text phpmd.ruleset.xml"
   }
 }

--- a/src/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeper.php
+++ b/src/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeper.php
@@ -80,6 +80,12 @@ final class FailoverAwareAliveKeeper implements AliveKeeper
                     'exception' => $e,
                 ]
             );
+
+            try {
+                $this->reconnect();
+            } catch (DBALException $e) {
+                // this is usual reconnect
+            }
         }
     }
 

--- a/tests/Unit/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeperTest.php
+++ b/tests/Unit/DBAL/Connection/FailoverAware/FailoverAwareAliveKeeperTest.php
@@ -131,8 +131,8 @@ class FailoverAwareAliveKeeperTest extends TestCase
         /** @var $connectionProphecy Connection|ObjectProphecy */
         $connectionProphecy = $this->prophesize(Connection::class);
         $connectionProphecy->query(Argument::any())->willReturn($statementProphecy->reveal())->shouldBeCalled();
-        $connectionProphecy->close()->shouldBeCalledTimes(0);
-        $connectionProphecy->connect()->shouldBeCalledTimes(0);
+        $connectionProphecy->close()->shouldBeCalled();
+        $connectionProphecy->connect()->shouldBeCalled();
 
         $aliveKeeper = new FailoverAwareAliveKeeper(
             $loggerProphecy->reveal(),


### PR DESCRIPTION
this commit returned the connection reconnect call removed in previous commit (but with the difference that now the exceptions from the call are caught), so the alive keeper stopped reconnecting when it wasn't able to get the reader/writer status.