### PR TITLE
Allow upgrade symfony/orm-pack to version 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "sensio/framework-extra-bundle": "^5.2",
     "symfony/config": "^4.1|^5.0|^5.1",
     "symfony/dependency-injection": "^4.1|^5.0|^5.1",
-    "symfony/orm-pack": "^1.0",
+    "symfony/orm-pack": "^1.0|^2.0",
     "symfony/yaml": "^4.1|^5.0|^5.1"
   },
   "autoload": {


### PR DESCRIPTION
v symfony/orm-pack boli od verzie `1.1.0` upravene constraints pre doctrine .
kym `1.0.8` male este `doctrine/doctrine-migrations-bundle: *`
`1.1.0` uz ma len `doctrine/doctrine-migrations-bundle: ^2`

cize v povodnej 1.0.8 bolo mozne nainstalovat doctrine migration vo verzie 3.x, v 1.0 to uz mozne nie je.
preto treba extendnut moznost instalacia aj o 2.0 (aj ked v zasade by stacilo ^2.0 kedze vsade su `*` 