### PR TITLE
ResettableEntityManager - resetIfNeeded method is back again because …

### DIFF
--- a/src/DependencyInjection/CompilerPass/EntityManagerDecoratorPass.php
+++ b/src/DependencyInjection/CompilerPass/EntityManagerDecoratorPass.php
@@ -36,6 +36,8 @@ final class EntityManagerDecoratorPass implements CompilerPassInterface
             $decoratorDef = new Definition(ResettableEntityManager::class, [
                 '$configuration' => $configArg,
                 '$wrapped' => new Reference($newId),
+                '$doctrineRegistry' => new Reference('doctrine'),
+                '$decoratedName' => $name,
             ]);
             $decoratorDef->setPublic(true);
 


### PR DESCRIPTION
…it can be used in some scenarios, e.g. exception handling